### PR TITLE
Revise enterprise suite image versions

### DIFF
--- a/cloudflow-enterprise-components/values.yaml
+++ b/cloudflow-enterprise-components/values.yaml
@@ -24,8 +24,8 @@ enterprise-suite:
   esConsoleVersion: v1.4.8
   esMonitorVersion: v1.2.5
   esGrafanaVersion: v0.3.5
-  prometheusVersion: v2.19.3
-  configMapReloadVersion: v0.2.2
+  prometheusVersion: v2.21.0
+  configMapReloadVersion: v0.4.0
   kubeStateMetricsVersion: v1.9.7
-  alpineVersion: "3.9"
-  busyboxVersion: "1.30"
+  alpineVersion: "3.12"
+  busyboxVersion: "1.32"


### PR DESCRIPTION
From some tests in my own deployment, these image versions appear to work. This removes a large number of vulnerabilities detected by xray when scanning the docker images used by a complete deployment.