### PR TITLE
Bump enterprise components images

### DIFF
--- a/cloudflow-enterprise-components/values.yaml
+++ b/cloudflow-enterprise-components/values.yaml
@@ -16,9 +16,9 @@ enterprise-suite:
   kubeStateMetricsImage: quay.io/coreos/kube-state-metrics
   alpineImage: alpine
   busyboxImage: busybox
-  esConsoleVersion: v1.4.8
+  esConsoleVersion: v1.4.10-RC1
   esMonitorVersion: v1.2.5
-  esGrafanaVersion: v0.3.5
+  esGrafanaVersion: v0.5.0-RC1
   prometheusVersion: v2.21.0
   configMapReloadVersion: v0.4.0
   kubeStateMetricsVersion: v1.9.7


### PR DESCRIPTION
Based on:
https://github.com/lightbend/console-charts/pull/490

@RayRoestenburg is it fine to use `RC` releases?