### PR TITLE
Add commercial registry helper yaml

### DIFF
--- a/commercial-registry.yaml
+++ b/commercial-registry.yaml
@@ -1,0 +1,8 @@
+enterpriseOperator:
+  image: commercial-registry.lightbend.com/lightbend-cloudflow-enterprise-operator
+enterprise-suite:
+  esConsoleImage: commercial-registry.lightbend.com/enterprise-suite-es-console
+  esMonitorImage: commercial-registry.lightbend.com/enterprise-suite-console-api
+  esGrafanaImage: commercial-registry.lightbend.com/enterprise-suite-es-grafana
+  imageCredentials:
+    registry: commercial-registry.lightbend.com


### PR DESCRIPTION
This is a proposal to ease customer migration.
The helm command to install/upgrade cloudflow enterprise components needs just one extra line:
```
-f https://raw.githubusercontent.com/lightbend/cloudflow-helm-charts/commercial-registry/commercial-registry.yaml
```

In practice we should ask all the customers to run a command like:
```
helm upgrade -i cloudflow-enterprise-components cloudflow-helm-charts/cloudflow-enterprise-components \
  --namespace cloudflow \
  -f https://raw.githubusercontent.com/lightbend/cloudflow-helm-charts/commercial-registry/commercial-registry.yaml \
  --set enterpriseOperator.version=<version> \
  --set enterprise-suite.imageCredentials.username="<username>" \
  --set enterprise-suite.imageCredentials.password="<password>"
```
*before* the Bintray sunset on May 1st.